### PR TITLE
Make possible to use default aws creds (service account included)

### DIFF
--- a/pkg/controller/aws/aws_helper.go
+++ b/pkg/controller/aws/aws_helper.go
@@ -98,17 +98,21 @@ func UpdateNetworkLoadBalancer(loadBalancerDNS string, serviceNameTagValue strin
 func newAPIClient(id string, secret string, region string) (*APIClient, error) {
 
 	// Get AWS config
-	awsConfig := &aws.Config{
-		Region:      aws.String(region),
-		Credentials: credentials.NewStaticCredentials(id, secret, ""),
+	awsConfig := &aws.Config{}
+	if ( id == "" || secret == "" ) {
+		awsConfig = &aws.Config{
+			Region:      aws.String(region),
+		}
+	} else {
+		awsConfig = &aws.Config{
+			Region:      aws.String(region),
+			Credentials: credentials.NewStaticCredentials(id, secret, ""),
+		}
 	}
 
 	// Initialize an AWS session
 	awsConfig = awsConfig.WithCredentialsChainVerboseErrors(true)
-	sess, err := session.NewSession(awsConfig)
-	if err != nil {
-		return nil, fmt.Errorf("Unable to initialize AWS session: %v", err)
-	}
+	sess := session.Must(session.NewSession(awsConfig))
 
 	// Return AWS clients for ELBV2 and ResourceGroupsTaggingAPI
 	return &APIClient{


### PR DESCRIPTION
https://github.com/3scale/aws-nlb-helper-operator/issues/6

Also:
container runs as nonroot user
And it's makes problem with access to token
```
      securityContext:
        fsGroup: 65534
```
it resolve